### PR TITLE
Allow radio input checked "0" value successfully

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -334,7 +334,7 @@ class Html
     {
         return $this->input('radio', $name, $value)
             ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.str_slug($value)))
-            ->attributeIf(($value && $this->old($name) == $value) || $checked, 'checked');
+            ->attributeIf((! is_null($value) && $this->old($name) == $value) || $checked, 'checked');
     }
 
     /**


### PR DESCRIPTION
To fix "0" value cannot be checked.
Example:
```
{{ html()->model(new User(['is_admin' => '0'])) }}
{{ html()->radio('is_admin', null, '1') }}
{{ html()->radio('is_admin', null, '0') }}
```